### PR TITLE
build: Include AudioPackage14.mk instead of AllAudio.mk

### DIFF
--- a/target/product/full_base.mk
+++ b/target/product/full_base.mk
@@ -50,7 +50,7 @@ PRODUCT_PROPERTY_OVERRIDES := \
 PRODUCT_LOCALES := en_US
 
 # Get some sounds
-$(call inherit-product-if-exists, frameworks/base/data/sounds/AllAudio.mk)
+$(call inherit-product-if-exists, frameworks/base/data/sounds/AudioPackage14.mk)
 
 # Get a list of languages.
 $(call inherit-product, $(SRC_TARGET_DIR)/product/languages_full.mk)


### PR DESCRIPTION
* AllAudio.mk doesn't contain latest material files and also
  contains multiple duplicate files. Just copy the latest
  material ones and we'll include the older files in vendor/lineage

Change-Id: I7afdd9b94cc8148fa4ca58fe28310215aed8d27b